### PR TITLE
Add arm64 Support

### DIFF
--- a/cursor/cursor_arm64.go
+++ b/cursor/cursor_arm64.go
@@ -1,0 +1,45 @@
+package cursor
+
+import "sync/atomic"
+
+// Cursor marks a position in a ring buffer.
+type Cursor struct {
+	pos, mask int64
+
+	pad [48]byte
+}
+
+// New allocates a new Cursor at pos for a ring buffer mask.
+func New(pos, mask int) *Cursor {
+	return &Cursor{
+		pos:  int64(pos),
+		mask: int64(mask),
+	}
+}
+
+// Next returns the next position index.
+func (c *Cursor) Next() int {
+	return int((atomic.LoadInt64(&c.pos) + 1) & c.mask)
+}
+
+// Pos returns the current position index.
+func (c *Cursor) Pos() int {
+	return int(atomic.LoadInt64(&c.pos))
+}
+
+// Inc moves the position forward one space.
+func (c *Cursor) Inc() int {
+	for {
+		v1 := atomic.LoadInt64(&c.pos)
+		v2 := (v1 + 1) & c.mask
+
+		if atomic.CompareAndSwapInt64(&c.pos, v1, v2) {
+			return int(v2)
+		}
+	}
+}
+
+// Reset clears the position.
+func (c *Cursor) Reset() {
+	atomic.StoreInt64(&c.pos, -1)
+}

--- a/cursor/slice_arm64.go
+++ b/cursor/slice_arm64.go
@@ -1,0 +1,14 @@
+package cursor
+
+import "sync/atomic"
+
+// Alloc allocates the next unused or reset Cursor.
+func (s Slice) Alloc(pos int) *Cursor {
+	for {
+		for i := range s {
+			if atomic.CompareAndSwapInt64(&s[i].pos, -1, int64(pos)) {
+				return s[i]
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/benburkert/pubsub
+
+go 1.18


### PR DESCRIPTION
According to the  package [bug notes](https://pkg.go.dev/sync/atomic#pkg-note-BUG), on arm64 platforms the first word in an allocated struct is guaranteed to be 64 bit aligned. The cursor and slice packages only operate on the first item in the Cursor struct, so we should be good there.

I waffled a bunch on how to implement this, either making it the default, or using a file with multiple build tags. I ended up just copying it in a new file to make it clear that while the same code works, the two platforms have different behaviour and any changes made should consider this.

While here I did a `go mod init` as well.
